### PR TITLE
feat: add ability to force all nodes to be expanded

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ export default {
 | nodesDraggable   | Boolean       | Enable/disable drag & drop feature | false | No
 | contextMenu      | Boolean       | Enable/disable context menu | true | No
 | renameNodeOnDblClick | Boolean   | Enable/disable double click to rename feature | true | No
+| expandAll        | Boolean       | Expand/Collapse all nodes| false | No
 | contextMenuItems | Array of menu items         | Context menu items | [ { code: 'DELETE_NODE', label: 'Delete node' }, { code: 'RENAME_NODE', label: 'Rename node' } ] | No
 
 #### 2. Events

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -58,6 +58,7 @@
                         :showIcon="showIcon"
                         :prependIconClass="prependIconClass"
                         :contextMenu="contextMenu"
+                        :expandAll="expandAll"
                         @nodeSelect="childNodeSelect"
                         @nodeDragStart="nodeDragStart"
                         @deleteNode="deleteChildNode">
@@ -128,11 +129,16 @@
             contextMenu: {
                 type: Boolean,
                 default: true
+            },
+            // force all child nodes to be expanded
+            expandAll: {
+                type: Boolean,
+                default: false
             }
         },
         data() {
             return {
-                expanded: false,
+                expanded: this.expandAll,
                 selected: false,
                 nodeDragOver: false,
                 enterLeaveCounter: 0,

--- a/src/components/TreeView.vue
+++ b/src/components/TreeView.vue
@@ -22,6 +22,7 @@
                     :showIcon="showIcons"
                     :prependIconClass="prependIconClass"
                     :contextMenu="contextMenu"
+                    :expandAll="expandAll"
                     ref="rootNodes"
                     @nodeSelect="nodeSelect"
                     @nodeDragStart="nodeDragStart"
@@ -99,6 +100,11 @@
             },
             // show icons
             showIcons: {
+                type: Boolean,
+                default: false
+            },
+            // force all nodes to be expanded
+            expandAll: {
                 type: Boolean,
                 default: false
             }


### PR DESCRIPTION
I need a treeview that automatically starts with all nodes expanded.  Minor tweak to allow this.