### PR TITLE
Fix bug (reference to undefined $refs.ctxMenu)

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -28,7 +28,8 @@ export default {
   methods: {
     open(node) {
       this.activeNode = node
-      this.$refs.ctxMenu.open()
+      if (this.$refs.ctxMenu !== undefined)
+        this.$refs.ctxMenu.open()
     },
     menuItemSelected(item) {
       EventBus.$emit('contextMenuItemSelect', item, this.activeNode)


### PR DESCRIPTION
Error occurs by opening context menu when instance of treeview is destroyed and new one created.